### PR TITLE
Update summon-arm-toolchain

### DIFF
--- a/summon-arm-toolchain
+++ b/summon-arm-toolchain
@@ -443,7 +443,7 @@ if [ ! -e ${STAMPS}/${OOCD}.build ]; then
 				 --disable-werror \
 				 --prefix=${PREFIX} \
 				 --enable-dummy \
-				 --enable-ft2232_libftdi \
+				 --enable-libftdi \
 				 --enable-usb_blaster_libftdi \
 				 --enable-ep93xx \
 				 --enable-at91rm9200 \


### PR DESCRIPTION
Removed the use of --enable-ft2232_libftdi and added --enable-libftdi when building open-ocd to make it build on fedora 20
